### PR TITLE
remove duplicate dependency in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ jiwer
 pandas
 yt_dlp
 beautifulsoup4
-openai
 webvtt-py
 scipy
 tqdm


### PR DESCRIPTION
openai is a duplicate requirement (see line 17).
no effect on run, but reduce build time.